### PR TITLE
CMakeLists.txt: don't install libs or headers

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -103,10 +103,10 @@ endif()
 ########################################################################
 #
 # Install rules
-install(TARGETS gmock gmock_main
-  DESTINATION lib)
-install(DIRECTORY ${gmock_SOURCE_DIR}/include/gmock
-  DESTINATION include)
+#install(TARGETS gmock gmock_main
+#  DESTINATION lib)
+#install(DIRECTORY ${gmock_SOURCE_DIR}/include/gmock
+#  DESTINATION include)
 
 ########################################################################
 #

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -102,10 +102,10 @@ endif()
 ########################################################################
 #
 # Install rules
-install(TARGETS gtest gtest_main
-  DESTINATION lib)
-install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
-  DESTINATION include)
+#install(TARGETS gtest gtest_main
+#  DESTINATION lib)
+#install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
+#  DESTINATION include)
 
 ########################################################################
 #


### PR DESCRIPTION
We just want to link these statically to test programs

Installing these files makes rpmbuild complain about unpackaged files.
