### PR TITLE
googletest: 703209 Argument cannot be negative

### DIFF
--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -974,6 +974,8 @@ class CapturedStream {
     char name_template[] = "/tmp/captured_stream.XXXXXX";
 #  endif  // GTEST_OS_LINUX_ANDROID
     const int captured_fd = mkstemp(name_template);
+    GTEST_CHECK_(captured_fd != -1) << "Unable to open temporary file "
+                                    << name_template;
     filename_ = name_template;
 # endif  // GTEST_OS_WINDOWS
     fflush(NULL);


### PR DESCRIPTION
Fixed:

** CID 703209 (#1 of 1): Argument cannot be negative (NEGATIVE_RETURNS)
3. negative_returns: captured_fd is passed to a parameter that cannot be negative.

Signed-off-by: Amit Kumar amitkuma@redhat.com